### PR TITLE
Bug/show error output

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -154,6 +154,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
                 $dependencyProcess->mustRun();
             } catch (ProcessFailedException $e) {
                 $this->io->write($dependencyProcess->getOutput());
+                $this->io->write($dependencyProcess->getErrorOutput());
                 $this->io->write(
                     sprintf('<error>Failed to install dependencies for "%s" </error>', $package->getPrettyName())
                 );
@@ -167,6 +168,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
                 $buildProcess->mustRun();
             } catch (ProcessFailedException $e) {
                 $this->io->write($buildProcess->getOutput());
+                $this->io->write($buildProcess->getErrorOutput());
                 $this->io->write(
                     sprintf('<error>Static package "%s" failed to build </error>', $package->getPrettyName())
                 );


### PR DESCRIPTION
Looks like error output on yarn etc will go to STDERR and when an error occurs we're currently only showing the output before an error occurred. 

This will show output from both STDOUT and STDERR 