### PR TITLE
Fix timeout and env verification

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -127,7 +127,9 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
 
     public function verifyEnvironment() : bool
     {
-        return is_executable($this->getYarnExecutablePath());
+        if (!is_executable($this->getYarnExecutablePath())) {
+            throw new \RuntimeException('Yarn is not installed or executable!');
+        }
     }
 
     private function getYarnExecutablePath() : string
@@ -151,7 +153,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
             $dependencyProcess = new Process($this->getYarnExecutablePath());
 
             try {
-                $dependencyProcess->mustRun();
+                $dependencyProcess->setTimeout(300)->mustRun();
             } catch (ProcessFailedException $e) {
                 $this->io->write($dependencyProcess->getOutput());
                 $this->io->write($dependencyProcess->getErrorOutput());
@@ -165,7 +167,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
             $buildProcess = new Process('node_modules/.bin/cb release');
 
             try {
-                $buildProcess->mustRun();
+                $buildProcess->setTimeout(300)->mustRun();
             } catch (ProcessFailedException $e) {
                 $this->io->write($buildProcess->getOutput());
                 $this->io->write($buildProcess->getErrorOutput());


### PR DESCRIPTION
Currently getting random timeouts (not consistently though) with the builds so set the timeout to 5mins instead of the default 1min ... @shakyShane says this should be more than enough 

Also added an exception to the verify environment as when I ran in docker apparently it was fine even though it wasn't installed
