### PR TITLE
node-sass must be rebuilt after yarn install

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -125,6 +125,9 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
         ];
     }
 
+    /*
+     * @throws \RuntimeException When environment is invalid
+     */
     public function verifyEnvironment() : bool
     {
         if (!is_executable($this->getYarnExecutablePath())) {
@@ -150,7 +153,7 @@ class StaticsMergerPlugin implements PluginInterface, EventSubscriberInterface
             chdir($this->getInstallPath($package));
 
             $this->io->write(sprintf('<info>Installing dependencies for "%s"', $package->getPrettyName()));
-            $dependencyProcess = new Process($this->getYarnExecutablePath());
+            $dependencyProcess = new Process(sprintf('%s && npm rebuild node-sass', $this->getYarnExecutablePath()));
 
             try {
                 $dependencyProcess->setTimeout(300)->mustRun();


### PR DESCRIPTION
We need to rebuild node-sass after the yarn install of dependencies ... unfortunately from discussions with Shane there's not currently any way around this and it's a well known issue. 