### PR TITLE
Benjaminlill patch 1

### DIFF
--- a/src/StaticsMergerPlugin.php
+++ b/src/StaticsMergerPlugin.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types = 1);
 
 namespace Jh\StaticsMerger;
 


### PR DESCRIPTION
Composer issue [#5307](composer/composer#5307) 

Composer evals the plugin code with `?>` before it and this causes PHP to throw a wobbler